### PR TITLE
Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,12 @@
       <artifactId>commons-logging</artifactId>
       <version>1.1.3</version>
     </dependency>
+<!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
+<dependency>
+    <groupId>javax.xml.bind</groupId>
+    <artifactId>jaxb-api</artifactId>
+    <version>2.3.1</version>
+</dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
@@ -183,13 +189,18 @@
     </dependency>
   </dependencies>
 
-  <distributionManagement>
-    <site>
-      <id>apache.website</id>
-      <name>Apache Commons Site</name>
-      <url>scm:svn:https://svn.apache.org/repos/infra/websites/production/commons/content/proper/commons-scxml/</url>
-    </site>
-  </distributionManagement>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>artifactory</id>
+            <name>tact-snapshots</name>
+            <url>https://tact.jfrog.io/tact/maven-snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>artifactory</id>
+            <name>tact-releases</name>
+            <url>https://tact.jfrog.io/tact/maven-releases</url>
+        </repository>
+    </distributionManagement>
 
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/org/apache/commons/scxml2/SCInstance.java
+++ b/src/main/java/org/apache/commons/scxml2/SCInstance.java
@@ -18,6 +18,7 @@ package org.apache.commons.scxml2;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -314,11 +315,16 @@ public class SCInstance implements Serializable {
         if (data == null) {
             return;
         }
+        List<Data> toSet=new ArrayList<>();
         for (Data datum : data) {
-            if (getGlobalContext() == ctx && ctx.has(datum.getId())) {
-                // earlier/externally defined 'initial' value found: do not overwrite
-                continue;
-            }
+          if (getGlobalContext() == ctx && ctx.has(datum.getId())) {
+              // earlier/externally defined 'initial' value found: do not overwrite
+              continue;
+          } else {
+            toSet.add(datum);
+          }
+        }
+        for (Data datum : toSet) {
             Object value = null;
             boolean setValue = false;
             // prefer "src" over "expr" over "inline"

--- a/src/main/java/org/apache/commons/scxml2/SCInstance.java
+++ b/src/main/java/org/apache/commons/scxml2/SCInstance.java
@@ -26,8 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-
+import javax.script.ScriptException;
 import org.apache.commons.scxml2.env.SimpleContext;
+import org.apache.commons.scxml2.env.javascript.JSContext;
 import org.apache.commons.scxml2.env.javascript.JSEvaluator;
 import org.apache.commons.scxml2.io.ContentParser;
 import org.apache.commons.scxml2.model.Data;
@@ -380,6 +381,13 @@ public class SCInstance implements Serializable {
                     ctx.setLocal(datum.getId(), value);
                 }
             }
+        }
+        if (evaluator instanceof JSEvaluator) {
+          try {
+            ((JSEvaluator)evaluator).copyJavascriptGlobalsToScxmlContext((JSContext) ctx);
+          } catch (ScriptException e) {
+            throw new RuntimeException("error while copying js context back to scxml.", e);
+          }
         }
     }
 

--- a/src/main/java/org/apache/commons/scxml2/SCXMLExecutor.java
+++ b/src/main/java/org/apache/commons/scxml2/SCXMLExecutor.java
@@ -583,6 +583,7 @@ public class SCXMLExecutor implements SCXMLIOProcessor {
      */
     public boolean isWaitingFor(TriggerEvent event) throws ModelException {
       Step step = new Step(event);
+      ((SCXMLSemanticsImpl) semantics).setSystemEventVariable(exctx.getScInstance(), event, false);
       ((SCXMLSemanticsImpl) semantics).selectTransitions(exctx, step);
       List<SimpleTransition> trs = step.getTransitList();
       return trs != null && !trs.isEmpty();

--- a/src/main/java/org/apache/commons/scxml2/SCXMLExecutor.java
+++ b/src/main/java/org/apache/commons/scxml2/SCXMLExecutor.java
@@ -18,6 +18,7 @@ package org.apache.commons.scxml2;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -30,8 +31,10 @@ import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.ModelException;
 import org.apache.commons.scxml2.model.Observable;
 import org.apache.commons.scxml2.model.SCXML;
+import org.apache.commons.scxml2.model.SimpleTransition;
 import org.apache.commons.scxml2.model.TransitionTarget;
 import org.apache.commons.scxml2.semantics.SCXMLSemanticsImpl;
+import org.apache.commons.scxml2.semantics.Step;
 
 /**
  * <p>The SCXML &quot;engine&quot; that executes SCXML documents. The
@@ -571,4 +574,18 @@ public class SCXMLExecutor implements SCXMLIOProcessor {
             log.debug(sb.toString());
         }
     }
+   
+    /**
+     * returns true if the given event is expected by some state.
+     * @param event
+     * @return
+     * @throws ModelException
+     */
+    public boolean isWaitingFor(TriggerEvent event) throws ModelException {
+      Step step = new Step(event);
+      ((SCXMLSemanticsImpl) semantics).selectTransitions(exctx, step);
+      List<SimpleTransition> trs = step.getTransitList();
+      return trs != null && !trs.isEmpty();
+    }
+    
 }

--- a/src/main/java/org/apache/commons/scxml2/env/AbstractBaseEvaluator.java
+++ b/src/main/java/org/apache/commons/scxml2/env/AbstractBaseEvaluator.java
@@ -38,7 +38,7 @@ public abstract class AbstractBaseEvaluator implements Evaluator, Serializable {
     /**
      * Unique context variable name used for temporary reference to assign data (thus must be a valid variable name)
      */
-    private static final String ASSIGN_VARIABLE_NAME = "a"+ UUID.randomUUID().toString().replace('-','x');
+    protected static final String ASSIGN_VARIABLE_NAME = "a"+ UUID.randomUUID().toString().replace('-','x');
 
     /**
      * @see Evaluator#evalAssign(Context, String, Object)

--- a/src/main/java/org/apache/commons/scxml2/env/javascript/JSEvaluator.java
+++ b/src/main/java/org/apache/commons/scxml2/env/javascript/JSEvaluator.java
@@ -305,6 +305,15 @@ public class JSEvaluator extends AbstractBaseEvaluator {
         }
     }
     
+  public void copyJavascriptGlobalsToScxmlContext(final JSContext context) throws ScriptException {
+    JSContext effectiveContext = getEffectiveContext((JSContext) context);
+    ScriptContext scriptContext = getScriptContext(effectiveContext);
+    // copy Javascript global variables to SCXML context.
+    copyJavascriptGlobalsToScxmlContext(scriptContext.getBindings(ScriptContext.ENGINE_SCOPE),
+        effectiveContext);
+  }
+
+    
     /**
      * When directly injecting data in the local context, wrap Java array and List objects with a native Javascript
      * Array

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JSEvaluatorTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JSEvaluatorTest.java
@@ -267,7 +267,7 @@ public class JSEvaluatorTest {
     public void testScriptFunctions() throws Exception {
         context.set("FIVE", 5);
         Assertions.assertEquals(5,context.get("FIVE"));
-        Assertions.assertEquals(120.0, evaluator.eval(context,FUNCTION), "Invalid function result");
+        Assertions.assertEquals(120, evaluator.eval(context,FUNCTION), "Invalid function result");
     }
 
 


### PR DESCRIPTION
adding a method to query the fsm with an event (+data) to see if it's expected by the fsm. this is to speed up the segment logger.

fixed injection of data from scxml to javascript to enable reuse of a discarded javascript interpreter (once the fsm using it is going to be terminated).